### PR TITLE
Add: aes keychain reading, writing, gen, business

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,8 +21,8 @@ type Config struct {
 	Files       []string `koanf:"files"`
 
 	// FROM OTHER STUFF
-	RSAKey  *rsa.PrivateKey
-	AESKeys [][]byte
+	RSAKey    *rsa.PrivateKey
+	AESKeyMap map[string][]byte
 }
 
 // config.New: load `configPath` into `config.Config`

--- a/pkg/rsa/rsa.go
+++ b/pkg/rsa/rsa.go
@@ -1,0 +1,35 @@
+package rsa
+
+import (
+	"crypto"
+	"crypto/rsa"
+	"fmt"
+)
+
+// rsa.CreateSignature: hashes `payload` with `hashAlgo` then signs hashed `payload` with `key`
+// returns: signature or error
+func CreateSignature(key *rsa.PrivateKey, payload []byte, hashAlgo crypto.Hash) ([]byte, error) {
+	h := hashAlgo.HashFunc().New()
+
+	// doesnt return error
+	h.Write(payload)
+
+	signature, err := rsa.SignPKCS1v15(nil, key, hashAlgo, h.Sum(nil)[:])
+	if err != nil {
+		return nil, fmt.Errorf("rsa.CreateSignature: rsa.SignPKCS1v15: %w", err)
+	}
+	return signature, nil
+}
+
+// if err happens, signature isnt verified
+func VerifySignature(key *rsa.PublicKey, signature []byte, payload []byte, hashAlgo crypto.Hash) error {
+	h := hashAlgo.HashFunc().New()
+
+	h.Write(payload)
+
+	err := rsa.VerifyPKCS1v15(key, hashAlgo, h.Sum(nil)[:], signature)
+	if err != nil {
+		return fmt.Errorf("rsa.VerifySignature: rsa.VerifyPKCS1v15: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
big commit, im sorry i forgot :(. aes keychain reading and writing logic is all here. generation and business logic is all here too.

our keychain is defined as a map of the keys to their extensions that is signed and then encrypted by an RSA private key.

because of that, I chose json as the format, presigned and encrypted, itll look like
```json
{
    "<extension>": "<base64 aes key>",
}
```

**writing**
the logic of writing is
* marshal key map to json
* sign that json(using md5, trust i didnt want it either)
* append json to end of signature
* encrypt whole payload with public key
* write to file this will error out if file already exists, you can only have one keychain

**reading**
logic is basically the same as above except its in reverse
* read from file
* decrypt payload using private key
* verifies signature using public key
* unmarshals json to map

The business logic for aes keys is try to load them in, if dont exist gen.